### PR TITLE
Fix: Link Retriever

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,8 +6,8 @@
 		<Authors>$(Company)</Authors>
 		<Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
 		<Trademark>$(Company)™</Trademark>
-		<Product>XperienceCommunity.PageLinkTagHelpers</Product>
-		<VersionPrefix>2.0.0</VersionPrefix>
+		<Product>XperienceCommunity.PageLinks</Product>
+		<VersionPrefix>3.0.0</VersionPrefix>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Title>$(Product)</Title>
 		<PackageProjectUrl>https://github.com/wiredviews/xperience-page-link-tag-helpers</PackageProjectUrl>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Xperience Page Link Tag Helpers
+# Xperience Page Links
 
 [![GitHub Actions CI: Build](https://github.com/wiredviews/xperience-page-link-tag-helpers/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/wiredviews/xperience-page-link-tag-helpers/actions/workflows/ci.yml)
 
@@ -35,6 +35,10 @@ This package is compatible with ASP.NET Core 3.1+ applications or libraries inte
    > Populate the `Guid` values with the `NodeGUID` of each page in the content tree that you need to link to in your application.
 
    ```csharp
+   using XperienceCommunity.LinkablePages;
+   ```
+
+   ```csharp
    public namespace Sandbox.Shared
    {
       public class LinkablePage : ILinkablePage
@@ -60,6 +64,10 @@ This package is compatible with ASP.NET Core 3.1+ applications or libraries inte
    ```
 
 1. In the shared class library, create an implementation of the `ILinkablePageInventory` interface, which will be used to determine which Pages in the application should be protected:
+
+   ```csharp
+   using XperienceCommunity.LinkablePages;
+   ```
 
    ```csharp
    public class LinkablePageInventory : ILinkablePageInventory
@@ -97,6 +105,10 @@ This package is compatible with ASP.NET Core 3.1+ applications or libraries inte
 1. Register the library with ASP.NET Core DI:
 
    ```csharp
+   using XperienceCommunity.LinkablePages;
+   ```
+
+   ```csharp
    public void ConfigureServices(IServiceCollection services)
    {
        // Use standard registration
@@ -114,6 +126,8 @@ This package is compatible with ASP.NET Core 3.1+ applications or libraries inte
 1. Add the data protection custom module registration to your ASP.NET Core application (in `Startup.cs` or wherever you register your dependencies):
 
    ```csharp
+   using XperienceCommunity.LinkablePages;
+
    [assembly: RegisterModule(typeof(LinkablePageProtectionModule))]
    ```
 
@@ -129,6 +143,10 @@ This package is compatible with ASP.NET Core 3.1+ applications or libraries inte
    ```
 
 1. Create a custom module class in your CMS application to register the `LinkablePageProtectionModule` and the `ILinkablePageInventory` implementation:
+
+   ```csharp
+   using XperienceCommunity.LinkablePages;
+   ```
 
    ```csharp
    // Registers this custom module class

--- a/src/XperienceCommunity.LinkablePages/XperienceCommunity.LinkablePages.csproj
+++ b/src/XperienceCommunity.LinkablePages/XperienceCommunity.LinkablePages.csproj
@@ -3,14 +3,22 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>disable</Nullable>
+
+    <Description>
+      Provides abstraction and data protection for pages that can be linked to for Kentico Xperience 13.0 applications to help developers easily generate links to pages in the content tree.
+    </Description>
+
+    <Product>XperienceCommunity.LinkablePages</Product>
+    <Title>$(Product)</Title>
+    <PackageTags>$(PackageTags)</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Kentico.Xperience.Libraries" Version="[13.0.0, 13.1.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/XperienceCommunity.PageLinkTagHelpers/ILinkablePageLinkRetriever.cs
+++ b/src/XperienceCommunity.PageLinkTagHelpers/ILinkablePageLinkRetriever.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CMS.DocumentEngine;
 using CMS.DocumentEngine.Routing;
@@ -12,7 +13,7 @@ namespace XperienceCommunity.PageLinkTagHelpers
     /// </summary>
     public interface ILinkablePageLinkRetriever
     {
-        Task<LinkablePageLinkResult?> RetrieveAsync(Guid nodeGUID);
+        Task<LinkablePageLinkResult?> RetrieveAsync(Guid nodeGUID, CancellationToken token = default);
     }
 
     /// <summary>
@@ -30,7 +31,7 @@ namespace XperienceCommunity.PageLinkTagHelpers
             this.pageUrlRetriever = pageUrlRetriever;
         }
 
-        public async Task<LinkablePageLinkResult?> RetrieveAsync(Guid nodeGUID)
+        public async Task<LinkablePageLinkResult?> RetrieveAsync(Guid nodeGUID, CancellationToken token = default)
         {
             var pages = await pageRetriever
                 .RetrieveAsync<TreeNode>(
@@ -39,7 +40,8 @@ namespace XperienceCommunity.PageLinkTagHelpers
                         // Optimize returned columns, .WithPageUrlPaths() will add back the ones it needs
                         .Columns(nameof(TreeNode.DocumentName))
                         .WithPageUrlPaths(),
-                    cache => cache.Key($"page-link|{nodeGUID}"));
+                    cache => cache.Key($"page-link|{nodeGUID}"),
+                    cancellationToken: token);
 
             var page = pages.FirstOrDefault();
 

--- a/src/XperienceCommunity.PageLinkTagHelpers/ServiceCollectionLinkablePageExtensions.cs
+++ b/src/XperienceCommunity.PageLinkTagHelpers/ServiceCollectionLinkablePageExtensions.cs
@@ -13,7 +13,7 @@ namespace XperienceCommunity.PageLinkTagHelpers
         /// <returns></returns>
         public static IServiceCollection AddXperienceCommunityPageLinks(this IServiceCollection services)
         {
-            services.TryAddSingleton<ILinkablePageLinkRetriever, DefaultLinkablePageLinkRetriever>();
+            services.TryAddTransient<ILinkablePageLinkRetriever, DefaultLinkablePageLinkRetriever>();
 
             return services;
         }
@@ -28,7 +28,7 @@ namespace XperienceCommunity.PageLinkTagHelpers
         public static IServiceCollection AddXperienceCommunityPageLinks<TCustomLinkablePageLinkRetriever>(this IServiceCollection services)
             where TCustomLinkablePageLinkRetriever : class, ILinkablePageLinkRetriever
         {
-            services.TryAddSingleton<ILinkablePageLinkRetriever, TCustomLinkablePageLinkRetriever>();
+            services.TryAddTransient<ILinkablePageLinkRetriever, TCustomLinkablePageLinkRetriever>();
 
             return services;
         }
@@ -43,7 +43,7 @@ namespace XperienceCommunity.PageLinkTagHelpers
         public static IServiceCollection AddXperienceCommunityPageLinksProtection<TCustomLinkablePageInventory>(this IServiceCollection services)
             where TCustomLinkablePageInventory : class, ILinkablePageInventory
         {
-            services.TryAddSingleton<ILinkablePageInventory, TCustomLinkablePageInventory>();
+            services.TryAddTransient<ILinkablePageInventory, TCustomLinkablePageInventory>();
 
             return services;
         }


### PR DESCRIPTION
- Register Link Retriever as Transient instead of Singleton so it can accept transient/scoped dependencies
- Plumb `CancellationToken` as optional method param for link data retriever
- Docs
	- Add required `using` statements to code examples
	- Update project name to `Xperience Page Links`
- Add missing project metadata to `XperienceCommunity.LinkablePages` project
- Bump project version to 3.0.0